### PR TITLE
Add AI text detection endpoint with document parsing and Firestore logging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+AIORNOT_API_KEY=your_aiornot_key
+FIREBASE_SERVICE_ACCOUNT_BASE64=base64_encoded_service_account
+FIREBASE_PROJECT_ID=your_project_id

--- a/app/doc_text.py
+++ b/app/doc_text.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import io
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from typing import Literal, List, Dict
+
+from pypdf import PdfReader
+from pdf2image import convert_from_bytes
+from PIL import Image
+import pytesseract
+from docx import Document
+from pptx import Presentation
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+
+# ---------------- Dosya tespiti -----------------
+def detect_file_type(filename: str, content_type: str | None) -> Literal["pdf", "docx", "pptx", "ppt", "unknown"]:
+    """Dosya uzantısı ve MIME tipine göre belirleme."""
+    name = (filename or "").lower()
+    if name.endswith(".pdf") or content_type == "application/pdf":
+        return "pdf"
+    if name.endswith(".docx") or content_type == "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+        return "docx"
+    if name.endswith(".pptx") or content_type == "application/vnd.openxmlformats-officedocument.presentationml.presentation":
+        return "pptx"
+    if name.endswith(".ppt"):
+        return "ppt"
+    return "unknown"
+
+
+# ---------------- PDF -----------------
+def extract_text_from_pdf_bytes(pdf_bytes: bytes) -> str:
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    texts: List[str] = []
+    for page in reader.pages:
+        texts.append(page.extract_text() or "")
+    return "\n".join(texts)
+
+
+def extract_text_via_ocr(pdf_bytes: bytes, max_pages: int | None = None) -> str:
+    images = convert_from_bytes(pdf_bytes, first_page=1, last_page=max_pages)
+    ocr_texts = []
+    for image in images:
+        ocr_texts.append(pytesseract.image_to_string(image))
+    return "\n".join(ocr_texts)
+
+
+def split_pdf_by_pages(pdf_bytes: bytes, max_chars: int) -> List[Dict[str, str]]:
+    reader = PdfReader(io.BytesIO(pdf_bytes))
+    chunks: List[Dict[str, str]] = []
+    for i, page in enumerate(reader.pages, start=1):
+        text = page.extract_text() or ""
+        text = normalize_text(text)
+        for part in split_text_by_size(text, max_chars):
+            chunks.append({"source": f"page:{i}", "text": part})
+    return chunks
+
+
+# ---------------- DOCX -----------------
+def extract_text_from_docx_bytes(docx_bytes: bytes) -> List[Dict[str, str]]:
+    doc = Document(io.BytesIO(docx_bytes))
+    sections: List[Dict[str, str]] = []
+    current_name = "section:1"
+    current_text = []
+    index = 1
+    for para in doc.paragraphs:
+        if para.style.name.startswith("Heading") and para.text.strip():
+            if current_text:
+                sections.append({"source": current_name, "text": "\n".join(current_text)})
+                current_text = []
+                index += 1
+            current_name = f"section:{para.text.strip()}"
+        else:
+            current_text.append(para.text)
+    if current_text:
+        sections.append({"source": current_name, "text": "\n".join(current_text)})
+    if not sections:
+        sections.append({"source": "section:1", "text": ""})
+    return sections
+
+
+def extract_images_from_docx(docx_bytes: bytes) -> List[Image.Image]:
+    doc = Document(io.BytesIO(docx_bytes))
+    images: List[Image.Image] = []
+    for rel in doc.part.rels.values():
+        if "image" in rel.target_ref:
+            img_bytes = rel.target_part.blob
+            images.append(Image.open(io.BytesIO(img_bytes)))
+    return images
+
+
+# ---------------- PPTX -----------------
+def extract_text_from_pptx_bytes(pptx_bytes: bytes) -> List[Dict[str, str]]:
+    prs = Presentation(io.BytesIO(pptx_bytes))
+    slides: List[Dict[str, str]] = []
+    for i, slide in enumerate(prs.slides, start=1):
+        texts: List[str] = []
+        for shape in slide.shapes:
+            if getattr(shape, "has_text_frame", False):
+                texts.append(shape.text)
+        if getattr(slide, "has_notes_slide", False) and slide.notes_slide:
+            texts.append(slide.notes_slide.notes_text_frame.text)
+        slides.append({"source": f"slide:{i}", "text": "\n".join(texts)})
+    return slides
+
+
+def extract_images_from_pptx(pptx_bytes: bytes) -> List[Dict[str, Image.Image]]:
+    prs = Presentation(io.BytesIO(pptx_bytes))
+    images: List[Dict[str, Image.Image]] = []
+    for i, slide in enumerate(prs.slides, start=1):
+        for shape in slide.shapes:
+            if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
+                images.append({"slide": i, "image": Image.open(io.BytesIO(shape.image.blob))})
+    return images
+
+
+# ---------------- Legacy convert -----------------
+def convert_legacy_office_to_modern(tmp_path: str) -> str:
+    """LibreOffice ile eski ofis dosyasını modern formata çevirir."""
+    outdir = os.path.dirname(tmp_path)
+    cmd = ["libreoffice", "--headless", "--convert-to", "pdf", tmp_path, "--outdir", outdir]
+    result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.decode())
+    base, _ = os.path.splitext(tmp_path)
+    return base + ".pdf"
+
+
+# ---------------- Ortak -----------------
+def normalize_text(s: str) -> str:
+    s = s.replace("\r", "\n")
+    s = re.sub(r"[\t\v\f]+", " ", s)
+    s = re.sub(r"\s+", " ", s)
+    s = "".join(ch for ch in s if ch.isprintable())
+    return s.strip()
+
+
+def split_text_by_size(s: str, max_chars: int) -> List[str]:
+    return [s[i:i + max_chars] for i in range(0, len(s), max_chars) if s[i:i + max_chars]]
+
+
+def word_count(s: str) -> int:
+    return len(re.findall(r"\w+", s))
+
+
+def char_count(s: str) -> int:
+    return len(s)
+

--- a/endpoints/check_ai.py
+++ b/endpoints/check_ai.py
@@ -1,0 +1,275 @@
+import asyncio
+import logging
+import os
+from typing import List, Dict, Any
+
+import httpx
+import pytesseract
+from fastapi import UploadFile, File, Form, HTTPException
+from fastapi.responses import JSONResponse
+from main import app
+from firebase_admin import firestore
+
+from app.doc_text import (
+    detect_file_type,
+    extract_text_from_pdf_bytes,
+    extract_text_via_ocr,
+    split_pdf_by_pages,
+    extract_text_from_docx_bytes,
+    extract_images_from_docx,
+    extract_text_from_pptx_bytes,
+    extract_images_from_pptx,
+    normalize_text,
+    split_text_by_size,
+    word_count,
+    char_count,
+)
+
+
+logger = logging.getLogger(__name__)
+MAX_UPLOAD_MB = 25
+AIORNOT_API_KEY = os.getenv("AIORNOT_API_KEY", "")
+
+
+async def rate_limit_check() -> None:
+    """Basit rate limit placeholder."""
+    return None
+
+
+def interpret_messages_legacy(data: Dict[str, Any]) -> List[str]:
+    messages: List[str] = []
+    conf = data.get("confidence", 0.0)
+    ai_generated = data.get("ai_generated", False)
+    if ai_generated:
+        if conf >= 0.85:
+            messages.append("🤖 High Likely AI")
+        elif conf >= 0.6:
+            messages.append("🤖 Medium Likely AI")
+        else:
+            messages.append("🤖 Low Likely AI")
+    else:
+        if conf >= 0.85:
+            messages.append("🧑 High Likely Human")
+        elif conf >= 0.6:
+            messages.append("🧑 Medium Likely Human")
+        else:
+            messages.append("🧑 Low Likely Human")
+    quality = data.get("quality")
+    if quality:
+        messages.append(f"⭐ Quality: {quality}")
+    nsfw = data.get("nsfw")
+    if nsfw:
+        messages.append(f"🚫 NSFW: {nsfw}")
+    generator = data.get("generator")
+    if generator:
+        messages.append(f"🛠️ {generator}")
+    return messages
+
+
+def format_summary_tr(data: Dict[str, Any]) -> str:
+    conf = data.get("confidence", 0.0) * 100
+    verdict = "yapay zekâ" if data.get("ai_generated") else "insan"
+    quality = data.get("quality", "bilinmiyor")
+    nsfw = data.get("nsfw", "yok")
+    return f"Metnin %{conf:.1f} olasılıkla {verdict} tarafından üretildi. Kalite: {quality}. NSFW: {nsfw}."
+
+
+def _save_asst_message(user_id: str, chat_id: str, content: str, raw: Any) -> Dict[str, Any]:
+    db = firestore.client()
+    path = f"users/{user_id}/chats/{chat_id}/messages"
+    try:
+        ref = db.collection("users").document(user_id).collection("chats").document(chat_id).collection("messages").add({
+            "role": "assistant",
+            "content": content,
+            "meta": {"ai_detect": {"raw": raw}},
+        })
+        message_id = ref[1].id if isinstance(ref, tuple) else ref.id
+        return {"saved": True, "message_id": message_id, "path": path}
+    except Exception as e:  # pylint: disable=broad-except
+        logger.error("Firestore save error: %s", e)
+        return {"saved": False, "message_id": None, "path": path, "error": str(e)}
+
+
+@app.post("/check-ai")
+async def check_ai(
+    file: UploadFile = File(...),
+    user_id: str = Form(...),
+    chat_id: str = Form(...),
+    external_id: str | None = Form(None),
+    chunk_strategy: str | None = Form(None),
+    max_chars_per_chunk: int = Form(200000),
+    min_chars_required: int = Form(250),
+    ocr_for_pdf: bool = Form(True),
+    ocr_for_office_images: bool = Form(False),
+    office_legacy_convert: bool = Form(False),
+):
+    await rate_limit_check()
+
+    raw_bytes = await file.read()
+    if len(raw_bytes) > MAX_UPLOAD_MB * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="Dosya boyutu çok büyük")
+
+    file_type = detect_file_type(file.filename, file.content_type)
+    if file_type == "unknown":
+        raise HTTPException(status_code=415, detail="Desteklenmeyen dosya tipi")
+    if file_type == "ppt" and not office_legacy_convert:
+        raise HTTPException(status_code=415, detail="Legacy PPT dosyaları desteklenmiyor")
+
+    strategy_defaults = {"pdf": "size", "docx": "sections", "pptx": "slides"}
+    chunk_strategy = chunk_strategy or strategy_defaults.get(file_type, "size")
+    if chunk_strategy not in {"none", "pages", "size", "slides", "sections"}:
+        raise HTTPException(status_code=400, detail="Geçersiz chunk_strategy")
+
+    max_chars_per_chunk = min(max_chars_per_chunk, 500_000)
+
+    # Metin çıkarımı
+    chunks: List[Dict[str, str]] = []
+    ocr_used = False
+
+    if file_type == "pdf":
+        text = extract_text_from_pdf_bytes(raw_bytes)
+        if len(text.strip()) < min_chars_required and ocr_for_pdf:
+            text = extract_text_via_ocr(raw_bytes, None)
+            ocr_used = True
+        text = normalize_text(text)
+        if chunk_strategy == "pages":
+            chunks = split_pdf_by_pages(raw_bytes, max_chars_per_chunk)
+        else:
+            chunks = [{"source": "document", "text": text}]
+
+    elif file_type == "docx":
+        sections = extract_text_from_docx_bytes(raw_bytes)
+        if ocr_for_office_images:
+            for idx, img in enumerate(extract_images_from_docx(raw_bytes), start=1):
+                try:
+                    img_text = normalize_text(pytesseract.image_to_string(img))
+                except Exception:  # pylint: disable=broad-except
+                    img_text = ""
+                if img_text:
+                    sections.append({"source": f"image:{idx}", "text": img_text})
+        if chunk_strategy == "sections":
+            chunks = sections
+        else:
+            joined = normalize_text("\n".join(sec["text"] for sec in sections))
+            chunks = [{"source": "document", "text": joined}]
+
+    elif file_type == "pptx":
+        slides = extract_text_from_pptx_bytes(raw_bytes)
+        if ocr_for_office_images:
+            for img in extract_images_from_pptx(raw_bytes):
+                try:
+                    img_text = normalize_text(pytesseract.image_to_string(img["image"]))
+                except Exception:  # pylint: disable=broad-except
+                    img_text = ""
+                if img_text:
+                    slides.append({"source": f"slide:{img['slide']}", "text": img_text})
+        if chunk_strategy == "slides":
+            chunks = slides
+        else:
+            joined = normalize_text("\n".join(slide["text"] for slide in slides))
+            chunks = [{"source": "document", "text": joined}]
+    else:
+        raise HTTPException(status_code=415, detail="Desteklenmeyen dosya tipi")
+
+    # size veya none stratejileri
+    if chunk_strategy == "size":
+        joined = normalize_text("\n".join(c["text"] for c in chunks))
+        chunks = [{"source": f"size:{i+1}", "text": part} for i, part in enumerate(split_text_by_size(joined, max_chars_per_chunk))]
+    elif chunk_strategy == "none":
+        joined = normalize_text("\n".join(c["text"] for c in chunks))
+        chunks = [{"source": "document", "text": joined}]
+    else:
+        # ensure pieces not exceeding max
+        new_chunks: List[Dict[str, str]] = []
+        for c in chunks:
+            for part in split_text_by_size(c["text"], max_chars_per_chunk):
+                new_chunks.append({"source": c["source"], "text": part})
+        chunks = new_chunks
+
+    total_chars_extracted = sum(len(c["text"]) for c in chunks)
+    if total_chars_extracted < min_chars_required:
+        raise HTTPException(status_code=400, detail="Metin çıkarılamadı veya çok kısa. OCR deneyin / resim ağırlıklı olabilir.")
+
+    # AI or Not çağrıları
+    results: List[Dict[str, Any]] = []
+    provider_raw: List[Any] = []
+    total_words = 0
+    total_chars = 0
+    async with httpx.AsyncClient() as client:
+        for idx, chunk in enumerate(chunks, start=1):
+            wc = word_count(chunk["text"])
+            cc = char_count(chunk["text"])
+            total_words += wc
+            total_chars += cc
+            params = {}
+            if external_id:
+                params["external_id"] = f"{external_id}-chunk-{idx}"
+            data = {"text": chunk["text"]}
+            headers = {"Authorization": f"Bearer {AIORNOT_API_KEY}"}
+            for attempt in range(3):
+                try:
+                    resp = await client.post(
+                        "https://api.aiornot.com/v2/text/sync",
+                        params=params,
+                        data=data,
+                        headers=headers,
+                        timeout=60,
+                    )
+                    if resp.status_code == 200:
+                        rjson = resp.json()
+                        provider_raw.append(rjson)
+                        results.append({
+                            "index": idx,
+                            "source": chunk["source"],
+                            "word_count": wc,
+                            "character_count": cc,
+                            "is_detected": rjson.get("ai_generated", False),
+                            "confidence": rjson.get("confidence", 0.0),
+                            "provider_id": rjson.get("id"),
+                            "created_at": rjson.get("created_at"),
+                        })
+                        break
+                    if 400 <= resp.status_code < 500:
+                        raise HTTPException(status_code=resp.status_code, detail=resp.text)
+                except httpx.TimeoutException:
+                    if attempt == 2:
+                        raise HTTPException(status_code=504, detail="AI or Not zaman aşımı")
+                await asyncio.sleep(2 ** attempt)
+            else:
+                raise HTTPException(status_code=502, detail="AI or Not hizmet hatası")
+
+    ai_weight = sum(r["word_count"] for r in results if r["is_detected"])
+    human_weight = total_words - ai_weight
+    ai_generated = ai_weight >= human_weight
+    confidence = (
+        sum(r["confidence"] * r["word_count"] for r in results) / total_words if total_words else 0.0
+    )
+
+    merged_raw = {
+        "chunks": provider_raw,
+        "ai_generated": ai_generated,
+        "confidence": confidence,
+        "ocr_used": ocr_used,
+    }
+
+    summary = format_summary_tr({"ai_generated": ai_generated, "confidence": confidence})
+    messages = interpret_messages_legacy({"ai_generated": ai_generated, "confidence": confidence})
+    content = summary + "\nMessages: " + ", ".join(messages)
+    firebase_info = _save_asst_message(user_id, chat_id, content, merged_raw)
+
+    response = {
+        "document_type": file_type,
+        "ai_generated": ai_generated,
+        "confidence": confidence,
+        "total_words": total_words,
+        "total_characters": total_chars,
+        "chunks": results,
+        "firebase": firebase_info,
+        "provider_raw": merged_raw,
+    }
+    if not firebase_info.get("saved"):
+        response["firestore_error"] = firebase_info.get("error")
+
+    return JSONResponse(response)
+
+

--- a/main.py
+++ b/main.py
@@ -26,8 +26,9 @@ from pptx import Presentation
 from pptx.util import Inches, Pt
 from pptx.dml.color import RGBColor
 from pypdf import PdfReader
-from fastapi import FastAPI, UploadFile, HTTPException, Body, Form, APIRouter ,Query
+from fastapi import FastAPI, UploadFile, HTTPException, Body, Form, APIRouter, Query
 from fastapi.responses import JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from dotenv import load_dotenv
 from openai import OpenAI
@@ -56,6 +57,13 @@ if not firebase_admin._apps:
 
 
 app = FastAPI()
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 DEFAULT_MODEL = os.getenv("OPENAI_MODEL", "gpt-4")
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
@@ -476,6 +484,7 @@ import endpoints.image_caption
 import endpoints.generate_doc_advanced
 import endpoints.generate_ppt_advanced
 import endpoints.ai_detect_video
+import endpoints.check_ai
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,6 @@ soundfile
 numpy
 beautifulsoup4
 pandas
+pillow
+pdf2image
+pytesseract


### PR DESCRIPTION
## Summary
- add document text utilities supporting OCR and chunking
- create `/check-ai` endpoint to detect AI-generated text and record results in Firestore
- enable CORS and include new dependencies and environment example

## Testing
- `python -m py_compile app/doc_text.py endpoints/check_ai.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1b169f70883269ed79c70a3a67bb7